### PR TITLE
Fix lookup of lib[n]curses.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -73,10 +73,21 @@ dnl Checks for libraries.
 dnl AM_WITH_REGEX
 AC_CHECK_LIB(crypto, SHA1_Init, [], [AC_MSG_ERROR(openssl (libssl) is required)])
 if test "$with_readline" != no; then
-dnl readline usually needs libncurses, but on some systems (like netbsd) libcurses will do. so pick one and use it
-AC_CHECK_LIB(ncurses, initscr,,)
-AC_CHECK_LIB(curses, initscr,,)
-AC_MSG_CHECKING([if libreadline needs libncurses])
+dnl look for libncurses, fall back to libcurses if it's not found
+AC_CHECK_LIB(ncurses, initscr,
+			 LIBS="$LIBS -lncurses"
+			 HAVE_LIBNCURSES=
+			 ,
+			 AC_CHECK_LIB(curses, initscr,
+						  LIBS="$LIBS -lcurses"
+						  HAVE_LIBCURSES=
+						  ,
+						  AC_MSG_RESULT(no)
+						  )
+			 )
+AC_CHECK_LIB(readline, readline, [], [AC_MSG_ERROR(libreadline cannot be found)])
+dnl make sure libreadline works with the lib[n]curses we found
+AC_MSG_CHECKING([if libreadline works with curses])
 AC_LINK_IFELSE(
   [AC_LANG_PROGRAM(
     [[
@@ -87,26 +98,9 @@ AC_LINK_IFELSE(
   return (x?0:1);
     ]]
   )],
-  [AC_MSG_RESULT(no)
-    dnl maybe it needs libcurses
-    AC_LINK_IFELSE(
-      [AC_LANG_PROGRAM(
-        [[
-#include <stdio.h>
-#include <readline/readline.h>
-        ]],[[
-      char*x=readline("test");
-      return (x?0:1);
-        ]]
-      )],
-      [AC_MSG_RESULT(no)],
-      [CPPFLAGS="$CPPFLAGS -lcurses"
-       AC_MSG_RESULT(yes)])],
-  [CPPFLAGS="$CPPFLAGS -lncurses"
-   AC_MSG_RESULT(yes)])
-
-
-AC_CHECK_LIB(readline, readline, [], [AC_MSG_ERROR(libreadline can't be found)])
+  [AC_MSG_RESULT(yes)],
+  [AC_MSG_ERROR(no)]
+)
 fi
 
 dnl check for the X libraries

--- a/configure.ac
+++ b/configure.ac
@@ -24,13 +24,6 @@ if test -n "$with_openssl_dir" && test "$with_openssl_dir" != yes; then
 fi
 
 
-dnl --with-readline or without
-AC_ARG_WITH(readline, AC_HELP_STRING([--with-readline], [use readline for read input (default=yes)]),,with_readline=yes)
-if test "$with_readline" != no; then
-  AC_DEFINE(WITH_READLINE, 1, [Define to 1 to enable use of gnu libreadline for input])
-fi
-
-
 dnl --with-getopt_long or without
 dnl note: there is also a test to see if getopt_long exists. both it and this have to be true for it to be use
 AC_ARG_WITH(getopt_long, AC_HELP_STRING([--with-getopt_long], [use getopt_long to parse arguments (default=yes if available)]),,with_getopt_long=yes)
@@ -72,36 +65,6 @@ esac
 dnl Checks for libraries.
 dnl AM_WITH_REGEX
 AC_CHECK_LIB(crypto, SHA1_Init, [], [AC_MSG_ERROR(openssl (libssl) is required)])
-if test "$with_readline" != no; then
-dnl look for libncurses, fall back to libcurses if it's not found
-AC_CHECK_LIB(ncurses, initscr,
-			 LIBS="$LIBS -lncurses"
-			 HAVE_LIBNCURSES=
-			 ,
-			 AC_CHECK_LIB(curses, initscr,
-						  LIBS="$LIBS -lcurses"
-						  HAVE_LIBCURSES=
-						  ,
-						  AC_MSG_RESULT(no)
-						  )
-			 )
-AC_CHECK_LIB(readline, readline, [], [AC_MSG_ERROR(libreadline cannot be found)])
-dnl make sure libreadline works with the lib[n]curses we found
-AC_MSG_CHECKING([if libreadline works with curses])
-AC_LINK_IFELSE(
-  [AC_LANG_PROGRAM(
-    [[
-#include <stdio.h>
-#include <readline/readline.h>
-    ]],[[
-  char*x=readline("test"); 
-  return (x?0:1);
-    ]]
-  )],
-  [AC_MSG_RESULT(yes)],
-  [AC_MSG_ERROR(no)]
-)
-fi
 
 dnl check for the X libraries
 if test "$have_x" = yes; then
@@ -115,10 +78,6 @@ AC_HEADER_STDC
 AC_CHECK_HEADERS(unistd.h sys/param.h sys/time.h time.h sys/types.h sys/mkdev.h sys/sysmacros.h string.h memory.h fcntl.h dirent.h sys/ndir.h ndir.h alloca.h locale.h fcntl.h signal.h sys/select.h sys/resource.h sys/socket.h sys/un.h sys/mman.h)
 AC_CHECK_HEADERS(stdint.h errno.h termios.h getopt.h)
 AC_CHECK_HEADERS(openssl/sha.h openssl/blowfish.h openssl/rand.h, [], [AC_MSG_ERROR(openssl headers (libssl-dev) are required)])
-if test "$with_readline" != no; then
-AC_CHECK_HEADERS(curses.h, [], [AC_MSG_ERROR(curses.h (lib[n]curses-dev) is required by readline)])
-AC_CHECK_HEADERS(readline/readline.h, [], [AC_MSG_ERROR(readline/readline.h (libreadline-dev) can't be found)])
-fi
 AC_CHECK_HEADERS(netinet/in.h, [], [AC_MSG_ERROR(netinet/in.h is required)])
 if test "$have_x" = yes; then
 AC_CHECK_HEADERS(X11/Xlib.h X11/Xatom.h X11/Xmu/Atoms.h)
@@ -150,142 +109,6 @@ if test "$with_getopt_long" != no; then
 fi
 AC_CHECK_FUNC(tcsetattr, [], [AC_MSG_ERROR(tcsetattr() is needed)])
 AC_CHECK_FUNC(setrlimit, [AC_DEFINE(HAVE_SETRLIMIT, 1, [Define to 1 if setrlimit is supported])], [])
-if test "$with_readline" != no; then
-AC_CHECK_FUNC(readline, [], [AC_MSG_ERROR(readline() is needed)])
-fi
-
-
-if test "$with_readline" != no; then
-dnl older readline.h's declared readline() without any arguments and outside of 'extern "C"', which freaks out C++
-AC_LANG_PUSH(C++)
-AC_MSG_CHECKING([if readline.h needs extern "C"])
-AC_COMPILE_IFELSE(
-  [AC_LANG_PROGRAM(
-    [[
-#include <stdio.h>
-#include <readline/readline.h>
-    ]],[[
-  char*x=readline("test"); 
-  return (x?0:1);
-    ]]
-  )],
-  [AC_MSG_RESULT(no)], 
-  [AC_DEFINE(READLINE_H_NEEDS_EXTERN_C, 1, [Define to 1 if readline/readline.h needs extern "C"]) 
-   AC_MSG_RESULT(yes)])
-AC_LANG_POP(C++)
-fi
-
-
-if test "$with_readline" != no; then
-dnl slightly newer but still broken readline.h's use extern "C" but don't declare arguments as const
-AC_LANG_PUSH(C++)
-AC_MSG_CHECKING([if readline.h lacks 'const' in its declarations])
-AC_COMPILE_IFELSE(
-  [AC_LANG_PROGRAM(
-    [[
-#include <stdio.h>
-#if READLINE_H_NEEDS_EXTERN_C
-extern "C" {
-#endif
-#include <readline/readline.h>
-#if READLINE_H_NEEDS_EXTERN_C
-} // terminate extern "C"
-#endif
-
-    ]],[[
-  const char* prompt = "abc";
-  char*x = readline(prompt);
-    ]]
-  )],
-  [AC_MSG_RESULT(no)],
-  [AC_DEFINE(READLINE_H_USES_NO_CONST, 1, [Define to 1 if readline/readline.h doesn't properly declare arguments to be const])
-   AC_MSG_RESULT(yes)])
-AC_LANG_POP(C++)
-fi
-
-if test "$with_readline" != no; then
-dnl some other broken readline.h's use extern "C" and declare arguments for most everything, except for the callback functions
-AC_LANG_PUSH(C++)
-AC_MSG_CHECKING([if readline.h lacks types in its declaration of callbacks])
-AC_COMPILE_IFELSE(
-  [AC_LANG_PROGRAM(
-    [[
-#include <stdio.h>
-#if READLINE_H_NEEDS_EXTERN_C
-extern "C" {
-#endif
-#include <readline/readline.h>
-#if READLINE_H_NEEDS_EXTERN_C
-} // terminate extern "C"
-#endif
-
-#ifdef READLINE_H_USES_NO_CONST
-char* dummy_completion(char*, int) { return 0; }
-#else
-char* dummy_completion(const char*, int) { return 0; }
-#endif
-    ]],[[
-  rl_completion_entry_function = dummy_completion;
-    ]]
-  )],
-  [AC_MSG_RESULT(no)],
-  [AC_DEFINE(READLINE_H_LACKS_TYPES_FOR_CALLBACKS, 1, [Define to 1 if readline/readline.h lacks proper declarations for callbacks])
-   AC_MSG_RESULT(yes)])
-AC_LANG_POP(C++)
-fi
-
-
-if test "$with_readline" != no; then
-dnl some more readline.h's use extern "C" and declare const arguments, but the completion callback is expected to return int rather than char*
-AC_LANG_PUSH(C++)
-AC_MSG_CHECKING([if readline.h expects completion callbacks to return int])
-AC_COMPILE_IFELSE(
-  [AC_LANG_PROGRAM(
-    [[
-#include <stdio.h>
-#if READLINE_H_NEEDS_EXTERN_C
-extern "C" {
-#endif
-#include <readline/readline.h>
-#if READLINE_H_NEEDS_EXTERN_C
-} // terminate extern "C"
-#endif
-
-#ifdef READLINE_H_USES_NO_CONST
-int dummy_completion(char*, int) { return 0; }
-#else
-int dummy_completion(const char*, int) { return 0; }
-#endif
-    ]],[[
-  rl_completion_entry_function = dummy_completion;
-    ]]
-  )],
-  [AC_DEFINE(READLINE_H_COMPLETION_RETURNS_INT, 1, [Define to 1 if readline/readline.h completion callback should return int rather than char*])
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)])
-AC_LANG_POP(C++)
-fi
-
-
-dnl some systems do not supply getline()
-AC_MSG_CHECKING([if getline() is supported])
-AC_COMPILE_IFELSE(
-  [AC_LANG_PROGRAM(
-    [[
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
-#include <stdio.h>
-    ]],[[
-    char* buf = 0;
-    size_t len = 0;
-    getline(&buf,&len,0);
-    ]]
-  )],
-  [AC_DEFINE(HAS_GETLINE, 1, [Define to 1 if getline() is supported])
-   AC_MSG_RESULT(yes)],
-  [AC_MSG_RESULT(no)])
-
 
 
 dnl if we enabled debug, remove the -O2 and add -g; actually I override the -O2 by following it with -O0

--- a/pwsafe.cpp
+++ b/pwsafe.cpp
@@ -29,6 +29,7 @@
 #include "config.h"
 #endif
 
+#include <iostream>
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
@@ -83,30 +84,6 @@
 
 #include <termios.h>
 
-#if WITH_READLINE
-// fix a few things that system.h setup and that readline.h isn't going to like
-#undef ISDIGIT
-#undef IN_CTYPE_DOMAIN
-#if READLINE_H_NEEDS_EXTERN_C
-extern "C" {
-#endif
-#include <readline/readline.h>
-#if READLINE_H_NEEDS_EXTERN_C
-} // terminate extern "C"
-#endif
-
-#include <curses.h>
-
-#ifdef erase
-// some imbecile C programers #define erase() in [n]curses.h, which breaks std::<container>::erase(...)
-#undef erase
-#endif
-
-#else // WITH_READLINE
-// our cheap substitute for readline
-static char* readline(const char*);
-#endif // WITH_READLINE
-
 #ifndef HAS_GETOPT_LONG
 // our cheap substitute for getopt_long
 // for testing we might have included a getopt.h that did include getopt_long, so
@@ -148,9 +125,6 @@ typedef struct option long_option;
 typedef int socklen_t;
 #endif
 
-#ifndef HAS_GETLINE
-static ssize_t getline(char**,size_t*,FILE*);
-#endif
 
 // ---- secalloc and secstring classes ------------------------------------
 
@@ -634,10 +608,6 @@ int main(int argc, char **argv) {
         seteuid(getuid());
       }
 
-#if WITH_READLINE
-      rl_readline_name = const_cast<char*>(program_name); // so readline() can parse its config files and handle if (pwsafe) sections; some older readline's type rl_readline_name as char*, hence the const_cast
-#endif // WITH_READLINE
-
       // be nice and paranoid
       umask(0077);
 
@@ -915,7 +885,7 @@ static int parse(int argc, char **argv) {
           "v"   // verbose
           "g"   // debug
           "h"   // help
-          "V",	// version
+          "V",  // version
           long_options, (int *) 0)) != EOF)
   {
     switch (c) {
@@ -1101,94 +1071,50 @@ static const char* pwsafe_strerror(int err) {
   }
 }
 
-#if WITH_READLINE
-// there are 5 variations of readline.h out there, each of which needs a different declaration to compile cleanly
-#if READLINE_H_NEEDS_EXTERN_C
-extern "C" {
-  static dummy_completion()
-#elif READLINE_H_LACKS_TYPES_FOR_CALLBACKS
-  static int dummy_completion()
-#elif READLINE_H_USES_NO_CONST
-# if READLINE_H_COMPLETION_RETURNS_INT
-  static int dummy_completion(char*, int)
-# else
-  static char* dummy_completion(char*, int)
-# endif
-#else
-# if READLINE_H_COMPLETION_RETURNS_INT
-  static int dummy_completion(const char*, int)
-# else
-  // FYI this is the declaration which we normally end up picking
-  static char* dummy_completion(const char*, int)
-# endif
-#endif
-  {
-    return 0;
-  }
-#if READLINE_H_NEEDS_EXTERN_C
-} // extern "C"
-#endif
-#endif // WITH_READLINE
-
-// get a password from the user
-static secstring getpw(const char*const prompt) {
-  // turn off echo
+// get input from the user, possibly turning echo off
+static secstring getin(const char * prompt, const secstring& default_, bool echooff)
+{
   struct termios tio;
-  tcgetattr(STDIN_FILENO, &tio);
-  {
-    struct termios new_tio = tio;
-    new_tio.c_lflag &= ~(ECHO);
-    tcsetattr(STDIN_FILENO, TCSAFLUSH, &new_tio); // FLUSH so they don't get into the habit of typing ahead their passphrase
+  if (echooff) {
+    // turn off echo
+    tcgetattr(STDIN_FILENO, &tio);
+    {
+      struct termios new_tio = tio;
+      new_tio.c_lflag &= ~(ECHO);
+      tcsetattr(STDIN_FILENO, TCSAFLUSH, &new_tio); // FLUSH so they don't get into the habit of typing ahead their passphrase
+    }
   }
-#if WITH_READLINE
-  rl_completion_entry_function = dummy_completion; // we don't need readline doing any tab completion (and especially not filenames)
-#endif
-#if READLINE_H_USES_NO_CONST
-  char* x = readline(const_cast<char*>(prompt));
-#else
-  char* x = readline(prompt);
-#endif
+
+  // read line of input
+  std::cout << prompt;
+  std::cout.flush();
+  std::string x;
+  std::getline(std::cin, x);
   // restore echo
-  tcsetattr(STDIN_FILENO, TCSANOW, &tio);
+  if (echooff)
+    tcsetattr(STDIN_FILENO, TCSANOW, &tio);
   // echo a linefeed since the user's <Enter> was not echoed
   printf("\n");
-  // see what readline returned
-  if (x) {
-    secstring xx(x);
-    memset(x,0,strlen(x));
-    free(x);
-    return xx;
+  // do we have a line?
+  if (!std::cin.eof()) {
+    secstring xx(x.c_str(), x.size());
+    x.clear();
+    return xx.empty() ? default_ : xx;
   } else {
     // EOF/^d; abort
     throw FailEx();
   }
-}
-static inline secstring getpw(const std::string& prompt) { return getpw(prompt.c_str()); }
 
-static secstring gettxt(const char*const prompt, const secstring& default_="") {
-#if WITH_READLINE
-  rl_completion_entry_function = dummy_completion; // we don't need readline doing any tab completion (and especially not filenames)
-#endif
-#if READLINE_H_USES_NO_CONST
-  char* x = readline(const_cast<char*>(prompt));
-#else
-  char* x = readline(prompt);
-#endif
-  if (x) {
-    secstring xx(x);
-    memset(x,0,strlen(x));
-    free(x);
-    if (xx.empty())
-      return default_; // since default is also empty by default, this works out nicely when default is not used
-    else
-      return xx;
-  } else {
-    // EOF/^d; abort
-    throw FailEx();
-  }
 }
-static inline secstring gettxt(const std::string& prompt, const secstring& default_="") { return gettxt(prompt.c_str(), default_); }
-static inline secstring gettxt(const secstring& prompt, const secstring& default_="") { return gettxt(prompt.c_str(), default_); }
+
+// get a password from the user
+static secstring getpw(const std::string& prompt) {
+  return getin(prompt.c_str(), "", true);
+}
+
+static secstring gettxt(const secstring& prompt, const secstring& default_="") {
+  return getin(prompt.c_str(), default_, false);
+}
 
 static char get1char(const char*const prompt, const int def_val) {
   struct termios tio;
@@ -3058,72 +2984,6 @@ void* secalloc::reallocate(void* p, size_t old_n, size_t new_n) {
   return new_p;
 }
 
-// ----- cheap readline() substitute for without-readline builds ----------------------
-
-#ifndef WITH_READLINE
-// a cheap function with the same api as the real readline()
-static char* readline(const char* prompt) {
-  printf("%s", prompt);
-  fflush(stdout);
-  
-  static secstring saved;
-  int buflen = saved.length() + 100;
-  int bufpos = saved.length();
-  char* buf = reinterpret_cast<char*>(malloc(buflen+1));
-  if (!buf)
-    throw FailEx();
-  memcpy(buf, saved.data(), saved.length());
-  buf[saved.length()] = '\0';
-
-  while (!strchr(buf,'\n')) {
-    const int rc = ::read(STDIN_FILENO, buf+bufpos, buflen);
-
-    if (rc == -1) {
-      fprintf(stderr, "Error: %s read(STDIN) failed: %s\n", program_name, strerror(errno));
-      memset(buf,0,buflen);
-      free(buf);
-      throw FailEx();
-    }
-
-    bufpos += rc;
-    buf[bufpos] = '\0';
-
-    if (rc == 0) {
-      // EOF (ctrl-D)
-      break;
-    }
-
-    if (bufpos == buflen && !strchr(buf,'\n')) {
-      // we needed a bigger buffer
-      char* new_buf = reinterpret_cast<char*>(malloc(2*buflen+1));
-      if (!new_buf) {
-        fprintf(stderr, "Error: %s out of memory\n", program_name);
-        memset(buf,0,buflen);
-        free(buf);
-        throw FailEx();
-      }
-
-      memcpy(new_buf, buf, bufpos);
-      memset(buf, 0, buflen);
-      free(buf);
-      buf = new_buf;
-      buflen *= 2;
-    }
-  }
-
-  char* lf = strchr(buf,'\n');
-  if (lf) {
-    // save the rest of the input for later
-    saved.assign(lf+1);
-    *lf = '\0';
-  } else {
-    saved.assign("",0);
-  }
-
-  return buf;
-}
-#endif // WITH_READLINE
-
 // --- cheap getopt_long() substitute ----------------------------------------------------------
 
 #ifndef HAS_GETOPT_LONG
@@ -3164,39 +3024,4 @@ static int getopt_long(int argc, char*const argv[], const char* short_opts, cons
   return '?';
 }
 #endif // HAS_GETOPT_LONG
-
-#ifndef HAS_GETLINE
-// a cheap substitute
-static ssize_t getline(char** bufp,size_t* buflenp,FILE* file) {
-  char* buf = *bufp;
-  size_t buflen = *buflenp;
-  ssize_t len = 0;
-
-  if (!buf) {
-    if (buflen == 0) buflen = 128;
-    buf = reinterpret_cast<char*>(malloc(buflen));
-    if (!buf) return -1;
-    *bufp = buf; 
-    *buflenp = buflen;
-  }
-
-  while (true) {
-    if (!fgets(buf+len, buflen-len, file))
-      break; // we've reached EOF
-    
-    len += strlen(buf+len);
-    if (buf[len-1] == '\n')
-      break; // we've reached a \n
-     
-    // we need a bigger buffer
-    buflen *= 2;
-    buf = reinterpret_cast<char*>(realloc(buf,buflen));
-    if (!buf) return -1;
-    *bufp = buf; 
-    *buflenp = buflen;
-  }
-
-  return len;
-}
-#endif // HAS_GETLINE
 


### PR DESCRIPTION
This commit revises a bit how a working curses implementation is identified
and how it is checked that readline links fine with that.
First, look for ncurses. If that is not found, look for curses. Then check
whether readline works with what we found. Additionally, this fixes a couple
of mostly innocent problems:
- -l[n]curses was erroneously added to CPPFLAGS
- if found, both -lcurses and -lncurses were added to LIBS
